### PR TITLE
Require tncs to be saved in the model

### DIFF
--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -14,5 +14,6 @@ feature "Sign up" do
 
     customer = Customer.last
     expect(customer.email).to eq "my@email.com"
+    expect(customer.terms_and_conditions).to be_truthy
   end
 end


### PR DESCRIPTION
You could make the tests pass by just defining a `attr_accessor` on the model.